### PR TITLE
Pass credentials to server

### DIFF
--- a/src/excalidraw-app/data/httpStorage.ts
+++ b/src/excalidraw-app/data/httpStorage.ts
@@ -62,6 +62,7 @@ export const saveToHttpStorage = async (
       roomId,
       roomKey,
     }),
+    credentials: "include",
   });
 
   console.log("Fetching drawing data");
@@ -92,6 +93,7 @@ export const saveToHttpStorage = async (
       roomKey,
       data: JSON.stringify(elements),
     }),
+    credentials: "include",
   });
 
   if (putResponse.ok) {
@@ -112,6 +114,7 @@ export const loadFromHttpStorage = async (
       roomId,
       roomKey,
     }),
+    credentials: "include",
   });
 
   const elements = await getSyncableElementsFromResponse(getResponse);
@@ -153,6 +156,7 @@ export const saveFilesToHttpStorage = async ({
             "File-Id": id,
           },
           body,
+          credentials: "include",
         });
         savedFiles.set(id, true);
       } catch (error: any) {
@@ -186,6 +190,7 @@ export const loadFilesFromHttpStorage = async (
               "Room-Key": roomKey,
               "File-Id": id,
             },
+            credentials: "include",
           },
         );
         if (response.status < 400) {


### PR DESCRIPTION
Pass cookies set in the web-app to the draw server.

Should have no impact as a standalone change. Merging this into main should auto-trigger draw app release.