### PR TITLE
fix file corruption issue

### DIFF
--- a/src/excalidraw-app/data/httpStorage.ts
+++ b/src/excalidraw-app/data/httpStorage.ts
@@ -211,6 +211,10 @@ export const loadFilesFromHttpStorage = async (
             dataURL,
             created: metadata?.created || Date.now(),
           });
+        } else if (response.status === 403) {
+          // Note that we don't consider this an "erroredFile" because we still want
+          // other connected clients to be able to load the file
+          console.error("File access forbidden", id);
         } else {
           erroredFiles.set(id, true);
         }


### PR DESCRIPTION
https://app.asana.com/0/1202104415031323/1206447714765271/f

By not marking the 403 file load as "error", we will ensure that other clients will continue to try to load the file data.

Testing:
Pre-release (completed):
* Try accessing a drawing that you do not have access to, while a client with access loads the same drawing in another tab, and verify that no corruption occurs

Post-release:
* Open up an immersion w/ drawing in two tabs and test it out